### PR TITLE
Closes #9: Added endpoint to validate tokens

### DIFF
--- a/src/main/java/com/jeisoneccel/my_finances/auth/AuthenticationController.java
+++ b/src/main/java/com/jeisoneccel/my_finances/auth/AuthenticationController.java
@@ -3,6 +3,7 @@ package com.jeisoneccel.my_finances.auth;
 import com.jeisoneccel.my_finances.auth.models.LoginModel;
 import com.jeisoneccel.my_finances.auth.models.RefreshModel;
 import com.jeisoneccel.my_finances.auth.models.RegistrationModel;
+import com.jeisoneccel.my_finances.auth.models.ValidateModel;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,5 +34,11 @@ public class AuthenticationController {
     public ResponseEntity<AuthenticationResponse> refresh(@RequestBody RefreshModel model, HttpServletRequest request) {
         return new ResponseEntity<>(service.refresh(model, request), HttpStatus.OK);
     }
+
+    @PostMapping({"/validate", "/validate"})
+    public ResponseEntity<AuthenticationResponse> validate(@RequestBody ValidateModel model, HttpServletRequest request) {
+        return new ResponseEntity<>(service.validate(model, request), HttpStatus.OK);
+    }
+
 
 }

--- a/src/main/java/com/jeisoneccel/my_finances/auth/AuthenticationService.java
+++ b/src/main/java/com/jeisoneccel/my_finances/auth/AuthenticationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jeisoneccel.my_finances.auth.models.LoginModel;
 import com.jeisoneccel.my_finances.auth.models.RefreshModel;
 import com.jeisoneccel.my_finances.auth.models.RegistrationModel;
+import com.jeisoneccel.my_finances.auth.models.ValidateModel;
 import com.jeisoneccel.my_finances.auth.refresh_tokens.RefreshToken;
 import com.jeisoneccel.my_finances.auth.refresh_tokens.RefreshTokenService;
 import com.jeisoneccel.my_finances.classes.users.User;
@@ -81,6 +82,14 @@ public class AuthenticationService {
 
         String accessToken = jwtUtils.generateToken(user.getEmail());
         return new AuthenticationResponse(accessToken, refreshToken.getToken());
+    }
+
+    public AuthenticationResponse validate(ValidateModel model, HttpServletRequest request) {
+        if (jwtUtils.isValidToken(model.accessToken())) {
+            return new AuthenticationResponse(model.accessToken(), model.refreshToken());
+        }
+
+        return refresh(new RefreshModel(model.refreshToken()), request);
     }
 
     public void authenticate(

--- a/src/main/java/com/jeisoneccel/my_finances/auth/models/ValidateModel.java
+++ b/src/main/java/com/jeisoneccel/my_finances/auth/models/ValidateModel.java
@@ -1,0 +1,4 @@
+package com.jeisoneccel.my_finances.auth.models;
+
+public record ValidateModel(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/jeisoneccel/my_finances/utils/JwtUtils.java
+++ b/src/main/java/com/jeisoneccel/my_finances/utils/JwtUtils.java
@@ -41,4 +41,13 @@ public class JwtUtils {
                 .getSubject();
     }
 
+    public boolean isValidToken(String token) {
+        try {
+            String username = extractUsername(token);
+            return username != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
## DESCRIPTION

- Added endpoint to validate tokens
- When cccessToken is valid, it returns the AuthenticationModel with the current tokens
- When accessToken is invalid, it refreshes tokens based on refreshToken
- When refreshToken is invalid, it returns an error with BadCredentials

## HOW WAS THIS TESTED?

Valid Tokens:
<img width="1882" height="876" alt="image" src="https://github.com/user-attachments/assets/8db0be97-4687-4722-8fdb-8737b41d7361" />

Invalid AccessToken with valid RefreshToken:
<img width="1888" height="864" alt="image" src="https://github.com/user-attachments/assets/25017e51-e998-40d7-a45b-1b95b540b666" />

Invalid Tokens:
<img width="1856" height="1250" alt="image" src="https://github.com/user-attachments/assets/e071a2d2-8966-4cc7-985d-712bb1b59c98" />

## CHECKLIST

- [X] Branch name: `<label>-<issue-number>-<short-description`
- [X] Commits messages: `Refs #issue-number: Short Description`
- [X] Pull Request title: `Refs #issue: Short Description` or `Closes #issue: Short Description`
- [X] All changes are related to the issue referred
- [X] I doubled checked my code and commits to keep them organized
- [X] I tested my code to make sure the changes work and doesn't create new errors